### PR TITLE
단건 조회 및 수정 api의 변경 사항을 적용한다

### DIFF
--- a/src/api/article.ts
+++ b/src/api/article.ts
@@ -19,8 +19,8 @@ export const articleApi = {
     return response.data.data;
   },
 
-  updateArticle: async (data: CreateArticleRequest & { id: number }) => {
-    const response = await axios.put(`${API_BASE_URL}/articles`, data);
+  updateArticle: async (id: number, data: CreateArticleRequest) => {
+    const response = await axios.put(`${API_BASE_URL}/articles/${id}`, data);
     return response.data;
   },
 };

--- a/src/api/article.ts
+++ b/src/api/article.ts
@@ -16,7 +16,7 @@ export const articleApi = {
 
   getArticle: async (id: string) => {
     const response = await axios.get<ArticleDetailResponse>(`${API_BASE_URL}/articles/${id}`);
-    return response.data;
+    return response.data.data;
   },
 
   updateArticle: async (data: CreateArticleRequest & { id: number }) => {

--- a/src/app/@modal/articles/edit/[id]/page.tsx
+++ b/src/app/@modal/articles/edit/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { articleApi } from '@/api/article';
-import { ArticleDetailResponse } from '@/types/article';
+import { ArticleDetail } from '@/types/article';
 
 interface Props {
   params: { id: string };
@@ -24,13 +24,11 @@ export default function EditArticleModal({ params }: Props) {
   });
 
   // Update form data when article is loaded
-  if (articleQuery.data?.result === 'SUCCESS' && title === '') {
-    const article = articleQuery.data.data;
+  if (articleQuery.data && title === '') {
+    const article = articleQuery.data;
     setTitle(article.title);
     setContent(article.content);
-    if (article.relateArticles) {
-      setSelectedArticleIds(article.relateArticles.map(article => article.id));
-    }
+    setSelectedArticleIds(article.relateArticles.map(article => article.id));
   }
 
   // Fetch all articles for the dropdown
@@ -59,10 +57,7 @@ export default function EditArticleModal({ params }: Props) {
 
   const updateArticleMutation = useMutation({
     mutationFn: (data: { title: string; content: string; relateArticleIds: { articleIds: number[] } }) =>
-      articleApi.updateArticle({
-        ...data,
-        id: parseInt(params.id, 10),
-      }),
+      articleApi.updateArticle(parseInt(params.id, 10), data),
     onSuccess: () => {
       router.back();
     },

--- a/src/app/articles/view/[id]/ViewArticleClient.tsx
+++ b/src/app/articles/view/[id]/ViewArticleClient.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { articleApi } from '@/api/article';
-import { ArticleDetailResponse } from '@/types/article';
+import { ArticleDetail } from '@/types/article';
 
 interface Props {
   id: string;
@@ -11,16 +11,14 @@ interface Props {
 
 export default function ViewArticleClient({ id }: Props) {
   const router = useRouter();
-  const [article, setArticle] = useState<ArticleDetailResponse['data'] | null>(null);
+  const [article, setArticle] = useState<ArticleDetail | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const fetchArticle = async () => {
       try {
-        const response = await articleApi.getArticle(id);
-        if (response.result === 'SUCCESS') {
-          setArticle(response.data);
-        }
+        const article = await articleApi.getArticle(id);
+        setArticle(article);
       } catch (error) {
         console.error('Failed to fetch article:', error);
       } finally {
@@ -80,8 +78,8 @@ export default function ViewArticleClient({ id }: Props) {
           <h2 className="text-2xl font-bold mb-4">{article.title}</h2>
           <div className="text-sm text-gray-500 mb-4">
             작성일: {new Date(article.createdAt).toLocaleString()}
-            {article.updatedAt !== article.createdAt && (
-              <> | 수정일: {new Date(article.updatedAt).toLocaleString()}</>
+            {article.publishedAt !== article.createdAt && (
+              <> | 발행일: {new Date(article.publishedAt).toLocaleString()}</>
             )}
           </div>
           <div className="prose prose-invert max-w-none">

--- a/src/app/articles/view/[id]/page.tsx
+++ b/src/app/articles/view/[id]/page.tsx
@@ -7,19 +7,18 @@ interface Props {
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const resolvedParams = await params;
   try {
-    const response = await articleApi.getArticle(params.id);
-    if (response.result === 'SUCCESS') {
-      const article = response.data;
-      return {
-        title: `${article.title} - Rhizome`,
-        description: article.content.substring(0, 160),
-        openGraph: {
-          title: article.title,
-          description: article.content.substring(0, 160),
-        },
-      };
-    }
+    const article = await articleApi.getArticle(resolvedParams.id);
+    const description = article.content ? article.content.substring(0, 160) : '';
+    return {
+      title: `${article.title} - Rhizome`,
+      description,
+      openGraph: {
+        title: article.title,
+        description,
+      },
+    };
   } catch (error) {
     console.error('Failed to fetch article metadata:', error);
   }
@@ -30,6 +29,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-export default function ViewArticlePage({ params }: Props) {
-  return <ViewArticleClient id={params.id} />;
-} 
+export default async function ViewArticlePage({ params }: Props) {
+  const resolvedParams = await params;
+  return <ViewArticleClient id={resolvedParams.id} />;
+}

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -65,16 +65,18 @@ export interface AllArticleResponse {
   };
 }
 
+export interface ArticleDetail {
+  id: number;
+  title: string;
+  content: string;
+  createdAt: string;
+  publishedAt: string;
+  relateArticles: ReferenceArticleResponse[];
+}
+
 export interface ArticleDetailResponse {
   result: 'SUCCESS' | 'FAIL';
-  data: {
-    id: number;
-    title: string;
-    content: string;
-    createdAt: string;
-    updatedAt: string;
-    relateArticles?: ReferenceArticleResponse[];
-  };
+  data: ArticleDetail;
   error: null | {
     code: string;
     message: string;


### PR DESCRIPTION
## 작업 개요
수정 API에서 ID를 body가 아닌 path value로 전달하도록 수정하고, 단건 조회 시 관계된 데이터를 표시하도록 기능을 추가하였습니다.

## 작업 사항
- 수정 API의 ID 전달 방식을 body에서 path value로 변경
- 단건 조회 API에 관계 데이터를 포함해 응답을 개선
